### PR TITLE
bump toolchain to stable

### DIFF
--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -7,7 +7,7 @@
     "rev": "3b6023654b917c8641ec5e626724a43380cff8f0",
     "opts": {},
     "name": "LSpec",
-    "inputRev?": "main",
+    "inputRev?": "3b6023654b917c8641ec5e626724a43380cff8f0",
     "inherited": false}},
   {"git":
    {"url": "https://github.com/leanprover/std4/",
@@ -15,5 +15,5 @@
     "rev": "642cbc9960b49a65a779b8fce56b05ff83cf9e35",
     "opts": {},
     "name": "std",
-    "inputRev?": "main",
+    "inputRev?": "642cbc9960b49a65a779b8fce56b05ff83cf9e35",
     "inherited": false}}]}

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -1,15 +1,19 @@
-{"version": 4,
+{"version": 5,
  "packagesDir": "lake-packages",
  "packages":
  [{"git":
    {"url": "https://github.com/lurk-lab/LSpec",
     "subDir?": null,
-    "rev": "88f7d23e56a061d32c7173cea5befa4b2c248b41",
+    "rev": "3b6023654b917c8641ec5e626724a43380cff8f0",
+    "opts": {},
     "name": "LSpec",
-    "inputRev?": "88f7d23e56a061d32c7173cea5befa4b2c248b41"}},
+    "inputRev?": "main",
+    "inherited": false}},
   {"git":
    {"url": "https://github.com/leanprover/std4/",
     "subDir?": null,
-    "rev": "2f23536b83bc91f329c3675f4eb061d029ba489a",
+    "rev": "642cbc9960b49a65a779b8fce56b05ff83cf9e35",
+    "opts": {},
     "name": "std",
-    "inputRev?": "2f23536b83bc91f329c3675f4eb061d029ba489a"}}]}
+    "inputRev?": "main",
+    "inherited": false}}]}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -22,10 +22,10 @@ extern_lib ffi pkg := do
   buildStaticLib (pkg.nativeLibDir / name) #[job]
 
 require std from git
-  "https://github.com/leanprover/std4/" @ "main"
+  "https://github.com/leanprover/std4/" @ "642cbc9960b49a65a779b8fce56b05ff83cf9e35"
 
 require LSpec from git
-  "https://github.com/lurk-lab/LSpec" @ "main"
+  "https://github.com/lurk-lab/LSpec" @ "3b6023654b917c8641ec5e626724a43380cff8f0"
 
 section ImportAll
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -10,23 +10,22 @@ lean_lib YatimaStdLib where
 def ffiC := "ffi.c"
 def ffiO := "ffi.o"
 
-target importTarget (pkg : Package) : FilePath := do
-  let oFile := pkg.oleanDir / ffiO
+target ffi.o pkg : FilePath := do
+  let oFile := pkg.buildDir / ffiO
   let srcJob ← inputFile $ pkg.dir / ffiC
-  buildFileAfterDep oFile srcJob fun srcFile => do
-    let flags := #["-I", (← getLeanIncludeDir).toString, "-fPIC"]
-    compileO ffiC oFile srcFile flags
+  let flags := #["-I", (← getLeanIncludeDir).toString, "-fPIC"]
+  buildO ffiC oFile srcJob flags
 
-extern_lib ffi (pkg : Package) := do
+extern_lib ffi pkg := do
   let name := nameToStaticLib "ffi"
-  let job ← fetch <| pkg.target ``importTarget
-  buildStaticLib (pkg.buildDir / defaultLibDir / name) #[job]
+  let job ← fetch <| pkg.target ``ffi.o
+  buildStaticLib (pkg.nativeLibDir / name) #[job]
 
 require std from git
-  "https://github.com/leanprover/std4/" @ "2f23536b83bc91f329c3675f4eb061d029ba489a"
+  "https://github.com/leanprover/std4/" @ "main"
 
 require LSpec from git
-  "https://github.com/lurk-lab/LSpec" @ "88f7d23e56a061d32c7173cea5befa4b2c248b41"
+  "https://github.com/lurk-lab/LSpec" @ "main"
 
 section ImportAll
 

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2023-05-16
+leanprover/lean4:stable


### PR DESCRIPTION
Check over the lakefile pretty carefully:
1) I updated the FFI target (since the old API seems to have been removed?)
2) I changed the dependencies to target `main` instead of specific commits now that `lake-manifest` has gotten pretty robust. Let me know if I should revert this change.